### PR TITLE
feat: Post-install open default browser on macOS

### DIFF
--- a/pkg/scripts/postinstall
+++ b/pkg/scripts/postinstall
@@ -3,5 +3,9 @@ mkdir -p /usr/local/share/func
 cp /opt/func/Templates/func.api.plist /Library/LaunchDaemons
 launchctl bootstrap system /Library/LaunchDaemons/func.api.plist
 sleep 2
-open http://localhost:3536
+
+# Open the default browser to the func web interface
+# If no default found, open Safari.
+DEFAULT_BROWSER=$(defaults read com.apple.LaunchServices/com.apple.launchservices.secure LSHandlers | grep -B 3 'LSHandlerURLScheme = http' | grep 'LSHandlerRoleAll' | tail -n 1 | awk -F'"' '{print $2}')
+open -b "${DEFAULT_BROWSER:-com.apple.Safari}" "http://localhost:3536"
 exit 0


### PR DESCRIPTION
This pull request includes a change to the `pkg/scripts/postinstall` file to improve the way the browser is opened to the func web interface. An addition to determine and open the default browser, falling back to Safari if no default is found.

* [`pkg/scripts/postinstall`](diffhunk://#diff-e8bb50c1ee42a876c012519e0c3562b757d0ed48fc621635abef4efc04420e82L6-R10): Added a script to determine the default browser using `defaults read` and `grep`, and open the func web interface in the default browser or Safari if no default is found